### PR TITLE
feat: track player balance in multiplayer blackjack

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -17,8 +17,8 @@ function scheduleNextRound() {
 }
 
 io.on('connection', socket => {
-  socket.on('join', ({ name }) => {
-    const seatIdx = game.joinSeat(socket.id, name);
+  socket.on('join', ({ name, balance }) => {
+    const seatIdx = game.joinSeat(socket.id, name, balance);
     socket.emit('joined', { seatIdx });
     io.emit('state', game.state as GameState);
   });

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,5 +1,12 @@
 export type Card = { suit: '♠' | '♥' | '♦' | '♣'; value: string; weight: number };
-export type Seat = { id: string; name: string; bet: number | null; hand: Card[]; done: boolean };
+export type Seat = {
+  id: string;
+  name: string;
+  bet: number | null;
+  hand: Card[];
+  done: boolean;
+  balance: number;
+};
 export type GameState = {
   deck: Card[];
   seats: (Seat | null)[]; // 7 seats


### PR DESCRIPTION
## Summary
- track bankroll per seat and prevent overbetting
- pay out winnings to player balances including blackjack bonus
- accept initial balance on join event

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890a29929f48324bf21cd018a0d9f1a