### PR TITLE
Add double down action for blackjack

### DIFF
--- a/client-phone/src/App.tsx
+++ b/client-phone/src/App.tsx
@@ -63,6 +63,10 @@ export default function App() {
     if (seatIdx !== null) socket.emit('stand', { seatIdx });
   };
 
+  const handleDouble = () => {
+    if (seatIdx !== null) socket.emit('double', { seatIdx });
+  };
+
   if (seatIdx === null) {
     return <SeatSelector onJoin={handleJoin} />;
   }
@@ -90,6 +94,7 @@ export default function App() {
           hand={seat.hand}
           onHit={handleHit}
           onStand={handleStand}
+          onDouble={handleDouble}
           isTurn={state.currentSeat === seatIdx}
           phase={state.phase}
         />

--- a/client-phone/src/components/HandView.tsx
+++ b/client-phone/src/components/HandView.tsx
@@ -6,11 +6,12 @@ interface Props {
   hand: Card[];
   onHit: () => void;
   onStand: () => void;
+  onDouble: () => void;
   isTurn: boolean;
   phase: 'play' | 'settle';
 }
 
-export default function HandView({ hand, onHit, onStand, isTurn, phase }: Props) {
+export default function HandView({ hand, onHit, onStand, onDouble, isTurn, phase }: Props) {
   const total = hand.reduce((sum, c) => sum + (['J','Q','K'].includes(c.value) ? 10 : c.value === 'A' ? 11 : +c.value), 0);
   return (
     <div className="flex flex-col items-center">
@@ -35,6 +36,11 @@ export default function HandView({ hand, onHit, onStand, isTurn, phase }: Props)
             onClick={onHit}
             disabled={!isTurn}
           >Hit</button>
+          <button
+            className="bg-blue-500 px-4 py-2 rounded disabled:opacity-50"
+            onClick={onDouble}
+            disabled={!isTurn}
+          >Double</button>
           <button
             className="bg-red-500 px-4 py-2 rounded disabled:opacity-50"
             onClick={onStand}

--- a/server/src/game.ts
+++ b/server/src/game.ts
@@ -110,6 +110,19 @@ export class Game {
     }
   }
 
+  double(seatIdx: number) {
+    const seat = this.state.seats[seatIdx];
+    if (!seat || this.state.currentSeat !== seatIdx) throw new Error();
+    if (seat.bet === null) throw new Error();
+    const additional = seat.bet;
+    if (seat.balance < additional) throw new Error('Insufficient balance');
+    seat.balance -= additional;
+    seat.bet += additional;
+    seat.hand.push(this.dealCard());
+    seat.done = true;
+    this.nextTurn();
+  }
+
   stand(seatIdx: number) {
     const seat = this.state.seats[seatIdx];
     if (!seat || this.state.currentSeat !== seatIdx) throw new Error();

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -43,6 +43,12 @@ io.on('connection', socket => {
     if (game.state.phase === 'settle') scheduleNextRound();
   });
 
+  socket.on('double', ({ seatIdx }) => {
+    game.double(seatIdx);
+    io.emit('state', game.state);
+    if (game.state.phase === 'settle') scheduleNextRound();
+  });
+
   socket.on('quit', () => {
     game.leaveSeat(socket.id);
     io.emit('state', game.state);


### PR DESCRIPTION
## Summary
- support doubling down by adding `double` action in server game logic
- propagate double-down through socket event and client UI

## Testing
- `npm --prefix server run build`
- `npm --prefix client-phone run build`


------
https://chatgpt.com/codex/tasks/task_e_6890b7023dd483248cace0a4ee4491f8