### PR TITLE
Add hand splitting support

### DIFF
--- a/client-phone/src/App.tsx
+++ b/client-phone/src/App.tsx
@@ -7,8 +7,9 @@ import HandView from './components/HandView';
 // shared types
 interface Card { suit: string; value: string; }
 interface Seat {
-  bet: number | null;
-  hand: Card[];
+  bets: number[];
+  hands: Card[][];
+  activeHand: number;
   done: boolean;
   balance: number;
 }
@@ -67,6 +68,10 @@ export default function App() {
     if (seatIdx !== null) socket.emit('double', { seatIdx });
   };
 
+  const handleSplit = () => {
+    if (seatIdx !== null) socket.emit('split', { seatIdx });
+  };
+
   if (seatIdx === null) {
     return <SeatSelector onJoin={handleJoin} />;
   }
@@ -86,15 +91,19 @@ export default function App() {
           onBet={handleBet}
           onSkip={handleSkip}
           onQuit={handleQuit}
-          disabled={seat?.bet !== null}
+          disabled={!!seat?.bets.length}
         />
       )}
       {['play', 'settle'].includes(state.phase) && seat && (
         <HandView
-          hand={seat.hand}
+          hands={seat.hands}
+          bets={seat.bets}
+          activeHand={seat.activeHand}
+          balance={seat.balance}
           onHit={handleHit}
           onStand={handleStand}
           onDouble={handleDouble}
+          onSplit={handleSplit}
           isTurn={state.currentSeat === seatIdx}
           phase={state.phase}
         />

--- a/client-phone/src/components/HandView.tsx
+++ b/client-phone/src/components/HandView.tsx
@@ -3,32 +3,45 @@ import { motion } from 'framer-motion';
 
 interface Card { suit: string; value: string; }
 interface Props {
-  hand: Card[];
+  hands: Card[][];
+  bets: number[];
+  activeHand: number;
+  balance: number;
   onHit: () => void;
   onStand: () => void;
   onDouble: () => void;
+  onSplit: () => void;
   isTurn: boolean;
   phase: 'play' | 'settle';
 }
 
-export default function HandView({ hand, onHit, onStand, onDouble, isTurn, phase }: Props) {
-  const total = hand.reduce((sum, c) => sum + (['J','Q','K'].includes(c.value) ? 10 : c.value === 'A' ? 11 : +c.value), 0);
+export default function HandView({ hands, bets, activeHand, balance, onHit, onStand, onDouble, onSplit, isTurn, phase }: Props) {
+  const calcTotal = (hand: Card[]) => hand.reduce((sum, c) => sum + (['J','Q','K'].includes(c.value) ? 10 : c.value === 'A' ? 11 : +c.value), 0);
+  const currentHand = hands[activeHand] || [];
+  const canSplit = isTurn && currentHand.length === 2 && currentHand[0].value === currentHand[1].value && balance >= (bets[activeHand] || 0);
   return (
     <div className="flex flex-col items-center">
-      <div className="flex space-x-2 mb-4">
-        {hand.map((c, i) => (
-          <motion.div
-            key={i}
-            className="w-16 h-24 bg-white rounded-lg shadow flex items-center justify-center text-xl font-bold"
-            layout
-            initial={{ y: -20, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-          >
-            {c.value}{c.suit}
-          </motion.div>
+      <div className="flex space-x-4 mb-4">
+        {hands.map((hand, idx) => (
+          <div key={idx} className={`flex flex-col items-center ${idx === activeHand ? 'border-2 border-yellow-400 p-2' : 'opacity-50'}`}>
+            <div className="flex space-x-1 mb-2">
+              {hand.map((c, i) => (
+                <motion.div
+                  key={i}
+                  className="w-12 h-20 bg-white rounded-lg shadow flex items-center justify-center text-lg font-bold"
+                  layout
+                  initial={{ y: -20, opacity: 0 }}
+                  animate={{ y: 0, opacity: 1 }}
+                >
+                  {c.value}{c.suit}
+                </motion.div>
+              ))}
+            </div>
+            <div className="text-sm">Bet: {bets[idx] ?? 0}</div>
+            <div className="text-sm">Total: {calcTotal(hand)}</div>
+          </div>
         ))}
       </div>
-      <div className="mb-4">Total: {total}</div>
       {phase === 'play' && (
         <div className="flex space-x-4">
           <button
@@ -36,6 +49,11 @@ export default function HandView({ hand, onHit, onStand, onDouble, isTurn, phase
             onClick={onHit}
             disabled={!isTurn}
           >Hit</button>
+          <button
+            className="bg-green-500 px-4 py-2 rounded disabled:opacity-50"
+            onClick={onSplit}
+            disabled={!canSplit}
+          >Split</button>
           <button
             className="bg-blue-500 px-4 py-2 rounded disabled:opacity-50"
             onClick={onDouble}

--- a/client-table/src/App.tsx
+++ b/client-table/src/App.tsx
@@ -3,7 +3,7 @@ import { socket } from './socket';
 import TableView from './components/TableView';
 
 interface Card { suit: string; value: string; }
-interface Seat { name: string; bet: number | null; balance: number; hand: Card[]; done: boolean; }
+interface Seat { name: string; bets: number[]; balance: number; hands: Card[][]; activeHand: number; done: boolean; }
 interface GameState {
   seats: (Seat | null)[];
   dealer: Card[];

--- a/client-table/src/components/TableView.tsx
+++ b/client-table/src/components/TableView.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
 import Card from './Card';
 
 interface CardType { suit: string; value: string; }
-interface SeatType { name: string; bet: number | null; balance: number; hand: CardType[]; done: boolean; }
+interface SeatType { name: string; bets: number[]; balance: number; hands: CardType[][]; activeHand: number; done: boolean; }
 interface Props { state: { seats: (SeatType|null)[]; dealer: CardType[]; currentSeat: number|null; phase: string; }; }
 
 export default function TableView({ state }: Props) {
@@ -14,10 +13,14 @@ export default function TableView({ state }: Props) {
           {s ? (
             <>
               <div className="font-semibold mb-2">{s.name} (${s.balance})</div>
-              <div>Bet: {s.bet ?? 0}</div>
-              <div className="flex mt-2 space-x-1">
-                {s.hand.map((c, j) => <Card key={j} card={c} />)}
-              </div>
+              {s.hands.map((hand, hIdx) => (
+                <div key={hIdx} className={`mb-2 flex flex-col items-center ${state.currentSeat === i && s.activeHand === hIdx ? 'border-2 border-yellow-300 p-1' : ''}`}>
+                  <div>Bet: {s.bets[hIdx] ?? 0}</div>
+                  <div className="flex mt-2 space-x-1">
+                    {hand.map((c, j) => <Card key={j} card={c} />)}
+                  </div>
+                </div>
+              ))}
             </>
           ) : (
             <div className="opacity-50">Empty</div>

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -49,6 +49,12 @@ io.on('connection', socket => {
     if (game.state.phase === 'settle') scheduleNextRound();
   });
 
+  socket.on('split', ({ seatIdx }) => {
+    game.split(seatIdx);
+    io.emit('state', game.state);
+    if (game.state.phase === 'settle') scheduleNextRound();
+  });
+
   socket.on('quit', () => {
     game.leaveSeat(socket.id);
     io.emit('state', game.state);

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -2,8 +2,9 @@ export type Card = { suit: '♠' | '♥' | '♦' | '♣'; value: string; weight:
 export type Seat = {
   id: string;
   name: string;
-  bet: number | null;
-  hand: Card[];
+  bets: number[];
+  hands: Card[][];
+  activeHand: number;
   done: boolean;
   balance: number;
 };


### PR DESCRIPTION
## Summary
- Track multiple hands and wagers per seat on the server and client
- Add game logic and socket event for splitting hands
- Render and control multiple hands in phone and table UIs with split option

## Testing
- `npm test` (server) *(fails: Missing script)*
- `npm run build` (server)
- `npm test` (client-phone) *(fails: Missing script)*
- `npm run build` (client-phone)
- `npm test` (client-table) *(fails: Missing script)*
- `npm run build` (client-table)


------
https://chatgpt.com/codex/tasks/task_e_6890bc970878832494a53f7621202f7a