### PR TITLE
Enable next-round bets during settlement phase

### DIFF
--- a/client-phone/src/App.tsx
+++ b/client-phone/src/App.tsx
@@ -12,6 +12,7 @@ interface Seat {
   activeHand: number;
   done: boolean;
   balance: number;
+  nextBet: number | null;
 }
 interface GameState {
   seats: (Seat | null)[];
@@ -85,13 +86,13 @@ export default function App() {
     <div className="p-4 max-w-md mx-auto">
       <h1 className="text-2xl font-bold mb-2">Blackjack — Seat {seatIdx + 1}</h1>
       <p className="mb-4">Bankroll: ${seat?.balance ?? 0}</p>
-      {state.phase === 'bet' && (
+      {['bet', 'settle'].includes(state.phase) && (
         <BetControls
           balance={seat?.balance ?? 0}
           onBet={handleBet}
           onSkip={handleSkip}
           onQuit={handleQuit}
-          disabled={!!seat?.bets.length}
+          disabled={state.phase === 'bet' ? !!seat?.bets.length : seat?.nextBet != null}
         />
       )}
       {['play', 'settle'].includes(state.phase) && seat && (

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -7,6 +7,8 @@ export type Seat = {
   activeHand: number;
   done: boolean;
   balance: number;
+  // wager queued for upcoming round; null until player responds
+  nextBet: number | null;
 };
 export type GameState = {
   deck: Card[];


### PR DESCRIPTION
## Summary
- allow queuing bets during the `settle` phase and start the next round only after all players respond
- track `nextBet` per seat and incorporate it when preparing the next round
- show bet controls during settlement on the phone client and disable after submitting a bet or skip

## Testing
- `cd server && npm test` *(fails: Missing script: "test")*
- `cd server && npm run build`
- `cd client-phone && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890cb6088d08324bf52509071f535f7