### PR TITLE
Restrict doubling after a hit

### DIFF
--- a/client-phone/src/components/HandView.tsx
+++ b/client-phone/src/components/HandView.tsx
@@ -41,6 +41,10 @@ export default function HandView({
     currentHand.length === 2 &&
     currentHand[0].value === currentHand[1].value &&
     balance >= (bets[activeHand] || 0);
+  const canDouble =
+    isTurn &&
+    currentHand.length === 2 &&
+    balance >= (bets[activeHand] || 0);
 
   return (
     <div className="flex flex-col items-center">
@@ -107,7 +111,7 @@ export default function HandView({
           <button
             className="bg-blue-500 px-4 py-2 rounded disabled:opacity-50"
             onClick={onDouble}
-            disabled={!isTurn}
+            disabled={!canDouble}
           >
             Double
           </button>

--- a/server/src/game.ts
+++ b/server/src/game.ts
@@ -133,11 +133,12 @@ export class Game {
   double(seatIdx: number) {
     const seat = this.state.seats[seatIdx];
     if (!seat || this.state.currentSeat !== seatIdx) throw new Error();
+    const hand = seat.hands[seat.activeHand];
+    if (hand.length !== 2) throw new Error('Cannot double after hitting');
     const bet = seat.bets[seat.activeHand];
     if (seat.balance < bet) throw new Error('Insufficient balance');
     seat.balance -= bet;
     seat.bets[seat.activeHand] += bet;
-    const hand = seat.hands[seat.activeHand];
     hand.push(this.dealCard());
     seat.activeHand++;
     if (seat.activeHand >= seat.hands.length) {


### PR DESCRIPTION
## Summary
- Disallow doubling after drawing additional cards on the server
- Disable the Double button unless the hand has exactly two cards and funds are available

## Testing
- `npm test` (server) *(fails: Missing script: "test")*
- `npm run build` (server)
- `npm test` (client-phone) *(fails: Missing script: "test")*
- `npm run build` (client-phone)`

------
https://chatgpt.com/codex/tasks/task_e_6890d499aa688324a783a7ee8cf5bdb5