### PR TITLE
Support reconnectable seats and disconnection handling

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -19,9 +19,14 @@ function maybeStartNextRound() {
 }
 
 io.on('connection', socket => {
-  socket.on('join', ({ name, balance }) => {
-    const seatIdx = game.joinSeat(socket.id, name, balance);
-    socket.emit('joined', { seatIdx });
+  socket.on('join', ({ name, balance, playerId }) => {
+    const { seatIdx, playerId: pid } = game.joinSeat(
+      socket.id,
+      name,
+      balance,
+      playerId,
+    );
+    socket.emit('joined', { seatIdx, playerId: pid });
     io.emit('state', game.state as GameState);
   });
 
@@ -66,7 +71,7 @@ io.on('connection', socket => {
   });
 
   socket.on('disconnect', () => {
-    game.leaveSeat(socket.id);
+    game.markDisconnected(socket.id);
     io.emit('state', game.state);
     maybeStartNextRound();
   });

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,6 +1,8 @@
 export type Card = { suit: '♠' | '♥' | '♦' | '♣'; value: string; weight: number };
 export type Seat = {
-  id: string;
+  playerId: string;
+  socketId: string;
+  connected: boolean;
   name: string;
   bets: number[];
   hands: Card[][];


### PR DESCRIPTION
## Summary
- track playerId, socketId and connection status for seats
- reuse seats on reconnect and auto-stand disconnected players
- update server events for join/reconnect and disconnection flow

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890e12add388324840db7862a71d191