### PR TITLE
Handle disconnects across phases

### DIFF
--- a/server/src/game.ts
+++ b/server/src/game.ts
@@ -98,18 +98,25 @@ export class Game {
     const seat = this.state.seats[idx]!;
     seat.connected = false;
     if (this.state.phase === 'bet') {
-      if (seat.bets.length === 0) {
-        seat.bets = [0];
-        seat.hands = [[]];
-        seat.activeHand = 0;
-        seat.done = true;
+      // auto place a zero bet so the round can proceed
+      if (seat.bets.length > 0 && seat.bets[0] > 0) {
+        // refund any existing bet
+        seat.balance += seat.bets[0];
       }
+      seat.bets = [0];
+      seat.hands = [[]];
+      seat.activeHand = 0;
+      seat.done = true;
     } else if (this.state.phase === 'play') {
       if (!seat.done) {
+        // stand on all remaining hands
         seat.activeHand = seat.hands.length;
         seat.done = true;
         if (this.state.currentSeat === idx) this.nextTurn();
       }
+    } else if (this.state.phase === 'settle') {
+      // queue a skip bet for the upcoming round
+      if (seat.nextBet === null) seat.nextBet = 0;
     }
   }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -72,8 +72,8 @@ io.on('connection', socket => {
 
   socket.on('disconnect', () => {
     game.markDisconnected(socket.id);
-    io.emit('state', game.state);
     maybeStartNextRound();
+    io.emit('state', game.state);
   });
 });
 


### PR DESCRIPTION
## Summary
- Automatically skip disconnected players by zeroing their bet in the betting phase and queuing a zero bet during settle
- Stand all remaining hands for disconnected players in the play phase and advance the turn
- Trigger next-round checks immediately after disconnections so queued rounds continue

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890e63ec8f88324a3608d923dd1b6f9