### PR TITLE
Emit player ID on join

### DIFF
--- a/client-phone/src/App.tsx
+++ b/client-phone/src/App.tsx
@@ -53,11 +53,11 @@ export default function App() {
     handleConnect();
     socket.on('connect', handleConnect);
 
-    socket.on('joined', ({ seatIdx, playerId: pid }) => {
+    socket.on('joined', ({ seatIdx, playerId }) => {
       setSeatIdx(seatIdx);
-      setPlayerId(pid);
+      setPlayerId(playerId);
       setShouldRejoin(true);
-      localStorage.setItem('playerId', pid);
+      localStorage.setItem('playerId', playerId);
       if (name) localStorage.setItem('name', name);
     });
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -20,13 +20,8 @@ function maybeStartNextRound() {
 
 io.on('connection', socket => {
   socket.on('join', ({ name, balance, playerId }) => {
-    const { seatIdx, playerId: pid } = game.joinSeat(
-      socket.id,
-      name,
-      balance,
-      playerId,
-    );
-    socket.emit('joined', { seatIdx, playerId: pid });
+    const joinResult = game.joinSeat(socket.id, name, balance, playerId);
+    socket.emit('joined', joinResult);
     io.emit('state', game.state as GameState);
   });
 


### PR DESCRIPTION
## Summary
- Send `playerId` along with seat index when a client joins the server
- Phone client stores the returned `playerId` for reconnection

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `npm run build` (server)
- `npm test` (client-phone) *(fails: Missing script "test")*
- `npm run build` (client-phone)


------
https://chatgpt.com/codex/tasks/task_e_6890e8a9b57c832481d095d391440065