### PR TITLE
feat: show seat connection status

### DIFF
--- a/client-phone/src/App.tsx
+++ b/client-phone/src/App.tsx
@@ -13,6 +13,7 @@ interface Seat {
   done: boolean;
   balance: number;
   nextBet: number | null;
+  connected: boolean;
 }
 interface GameState {
   seats: (Seat | null)[];
@@ -125,7 +126,12 @@ export default function App() {
 
   return (
     <div className="p-4 max-w-md mx-auto">
-      <h1 className="text-2xl font-bold mb-2">Blackjack — Seat {seatIdx + 1}</h1>
+      <h1 className="text-2xl font-bold mb-2">
+        Blackjack — Seat {seatIdx + 1}
+        {seat && !seat.connected && (
+          <span className="text-red-500 text-sm ml-2">(Disconnected)</span>
+        )}
+      </h1>
       <p className="mb-4">Bankroll: ${seat?.balance ?? 0}</p>
       {['bet', 'settle'].includes(state.phase) && (
         <BetControls
@@ -133,23 +139,28 @@ export default function App() {
           onBet={handleBet}
           onSkip={handleSkip}
           onQuit={handleQuit}
-          disabled={state.phase === 'bet' ? !!seat?.bets.length : seat?.nextBet != null}
+          disabled={
+            !seat?.connected ||
+            (state.phase === 'bet' ? !!seat?.bets.length : seat?.nextBet != null)
+          }
         />
       )}
       {['play', 'settle'].includes(state.phase) && seat && (
-        <HandView
-          hands={seat.hands}
-          bets={seat.bets}
-          activeHand={seat.activeHand}
-          balance={seat.balance}
-          onHit={handleHit}
-          onStand={handleStand}
-          onDouble={handleDouble}
-          onSplit={handleSplit}
-          isTurn={state.currentSeat === seatIdx}
-          phase={state.phase}
-          dealer={state.dealer}
-        />
+        <div className={seat.connected ? '' : 'opacity-50 pointer-events-none'}>
+          <HandView
+            hands={seat.hands}
+            bets={seat.bets}
+            activeHand={seat.activeHand}
+            balance={seat.balance}
+            onHit={handleHit}
+            onStand={handleStand}
+            onDouble={handleDouble}
+            onSplit={handleSplit}
+            isTurn={state.currentSeat === seatIdx && seat.connected}
+            phase={state.phase}
+            dealer={state.dealer}
+          />
+        </div>
       )}
     </div>
   );

--- a/client-table/src/App.tsx
+++ b/client-table/src/App.tsx
@@ -3,7 +3,15 @@ import { socket } from './socket';
 import TableView from './components/TableView';
 
 interface Card { suit: string; value: string; }
-interface Seat { name: string; bets: number[]; balance: number; hands: Card[][]; activeHand: number; done: boolean; }
+interface Seat {
+  name: string;
+  bets: number[];
+  balance: number;
+  hands: Card[][];
+  activeHand: number;
+  done: boolean;
+  connected: boolean;
+}
 interface GameState {
   seats: (Seat | null)[];
   dealer: Card[];

--- a/client-table/src/components/TableView.tsx
+++ b/client-table/src/components/TableView.tsx
@@ -2,22 +2,49 @@ import React from 'react';
 import Card from './Card';
 
 interface CardType { suit: string; value: string; }
-interface SeatType { name: string; bets: number[]; balance: number; hands: CardType[][]; activeHand: number; done: boolean; }
+interface SeatType {
+  name: string;
+  bets: number[];
+  balance: number;
+  hands: CardType[][];
+  activeHand: number;
+  done: boolean;
+  connected: boolean;
+}
 interface Props { state: { seats: (SeatType|null)[]; dealer: CardType[]; currentSeat: number|null; phase: string; }; }
 
 export default function TableView({ state }: Props) {
   return (
     <div className="grid grid-cols-4 gap-4">
       {state.seats.map((s, i) => (
-        <div key={i} className="bg-white bg-opacity-20 rounded-lg p-4 flex flex-col items-center">
+        <div
+          key={i}
+          className={`bg-white bg-opacity-20 rounded-lg p-4 flex flex-col items-center ${
+            s && !s.connected ? 'opacity-50' : ''
+          }`}
+        >
           {s ? (
             <>
-              <div className="font-semibold mb-2">{s.name} (${s.balance})</div>
+              <div className="font-semibold mb-2">
+                {s.name} (${s.balance})
+                {!s.connected && (
+                  <span className="ml-2 text-xs text-red-500">Disconnected</span>
+                )}
+              </div>
               {s.hands.map((hand, hIdx) => (
-                <div key={hIdx} className={`mb-2 flex flex-col items-center ${state.currentSeat === i && s.activeHand === hIdx ? 'border-2 border-yellow-300 p-1' : ''}`}>
+                <div
+                  key={hIdx}
+                  className={`mb-2 flex flex-col items-center ${
+                    state.currentSeat === i && s.activeHand === hIdx
+                      ? 'border-2 border-yellow-300 p-1'
+                      : ''
+                  }`}
+                >
                   <div>Bet: {s.bets[hIdx] ?? 0}</div>
                   <div className="flex mt-2 space-x-1">
-                    {hand.map((c, j) => <Card key={j} card={c} />)}
+                    {hand.map((c, j) => (
+                      <Card key={j} card={c} />
+                    ))}
                   </div>
                 </div>
               ))}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -2,7 +2,7 @@ export type Card = { suit: '♠' | '♥' | '♦' | '♣'; value: string; weight:
 export type Seat = {
   playerId: string;
   socketId: string;
-  connected: boolean;
+  connected: boolean; // whether player's socket is currently connected
   name: string;
   bets: number[];
   hands: Card[][];


### PR DESCRIPTION
## Summary
- document connection status on server Seat model
- surface seat connection state in phone client and disable controls when disconnected
- display connection badges and greyed-out seats on the table client

## Testing
- `npm test` *(server/client-phone/client-table; missing script)*
- `npm run build` *(server)*
- `npm run build` *(client-phone)*
- `npm run build` *(client-table)*

------
https://chatgpt.com/codex/tasks/task_e_6890eaafeccc8324899134bfe78f2b67