### PR TITLE
Handle join errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .DS_Store
+dist/

--- a/client-phone/src/App.tsx
+++ b/client-phone/src/App.tsx
@@ -62,6 +62,16 @@ export default function App() {
       if (name) localStorage.setItem('name', name);
     });
 
+    const handleJoinError = (message: string) => {
+      alert(`Join failed: ${message}. Please enter your name and balance again.`);
+      setPlayerId(null);
+      setShouldRejoin(false);
+      setSeatIdx(null);
+      localStorage.removeItem('playerId');
+      localStorage.removeItem('name');
+    };
+    socket.on('joinError', handleJoinError);
+
     const handleState = (s: GameState) => {
       setState(s);
       if (seatIdx !== null && !s.seats[seatIdx]) setSeatIdx(null);
@@ -71,6 +81,7 @@ export default function App() {
     return () => {
       socket.off('connect', handleConnect);
       socket.off('joined');
+       socket.off('joinError', handleJoinError);
       socket.off('state', handleState);
     };
   }, [playerId, shouldRejoin, seatIdx, name]);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -20,9 +20,14 @@ function maybeStartNextRound() {
 
 io.on('connection', socket => {
   socket.on('join', ({ name, balance, playerId }) => {
-    const joinResult = game.joinSeat(socket.id, name, balance, playerId);
-    socket.emit('joined', joinResult);
-    io.emit('state', game.state as GameState);
+    try {
+      const joinResult = game.joinSeat(socket.id, name, balance, playerId);
+      socket.emit('joined', joinResult);
+      io.emit('state', game.state as GameState);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Join failed';
+      socket.emit('joinError', message);
+    }
   });
 
   socket.on('bet', ({ seatIdx, amount }) => {


### PR DESCRIPTION
## Summary
- handle joinSeat errors and inform clients with `joinError`
- prompt phone client to re-enter name and balance on join errors
- ignore build artifacts

## Testing
- `npm --prefix server run build`
- `npm --prefix client-phone run build`
- `node` socket.io client script to emit `join` without name/balance

------
https://chatgpt.com/codex/tasks/task_e_6890f1138b7c832493ef2cde92614696