### PR TITLE
Handle expired session on join error

### DIFF
--- a/client-phone/src/App.tsx
+++ b/client-phone/src/App.tsx
@@ -62,13 +62,12 @@ export default function App() {
       if (name) localStorage.setItem('name', name);
     });
 
-    const handleJoinError = (message: string) => {
-      alert(`Join failed: ${message}. Please enter your name and balance again.`);
+    const handleJoinError = () => {
+      alert('Session expired. Please enter your name and balance again.');
       setPlayerId(null);
-      setShouldRejoin(false);
       setSeatIdx(null);
+      setShouldRejoin(false);
       localStorage.removeItem('playerId');
-      localStorage.removeItem('name');
     };
     socket.on('joinError', handleJoinError);
 
@@ -81,7 +80,7 @@ export default function App() {
     return () => {
       socket.off('connect', handleConnect);
       socket.off('joined');
-       socket.off('joinError', handleJoinError);
+      socket.off('joinError', handleJoinError);
       socket.off('state', handleState);
     };
   }, [playerId, shouldRejoin, seatIdx, name]);


### PR DESCRIPTION
## Summary
- reset client state when server rejects join to avoid hanging after restart

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6890f491eb608324864c1adaea5c9216