### PR TITLE
feat(client-phone): show dealer total on round over

### DIFF
--- a/client-phone/src/components/HandView.tsx
+++ b/client-phone/src/components/HandView.tsx
@@ -64,6 +64,9 @@ export default function HandView({
             </motion.div>
           ))}
         </div>
+        {phase === 'settle' && (
+          <div className="text-sm mt-2">Total: {calcTotal(dealer)}</div>
+        )}
       </div>
       <div className="flex space-x-4 mb-4">
         {hands.map((hand, idx) => (


### PR DESCRIPTION
## Summary
- display dealer's hand total during round settlement in phone client

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689118baeadc8324bf4f1df44bd79c97