### PR TITLE
Start play when player disconnects during betting

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -72,6 +72,9 @@ io.on('connection', socket => {
 
   socket.on('disconnect', () => {
     game.markDisconnected(socket.id);
+    if (game.state.phase === 'bet') {
+      game.startPlay();
+    }
     maybeStartNextRound();
     io.emit('state', game.state);
   });


### PR DESCRIPTION
## Summary
- begin gameplay automatically when a player disconnects mid-betting so remaining players don't wait

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm start` *(terminated with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68911a10fc88832499baa9e24c0b67f3