### PR TITLE
Refund bet when leaving seat during betting phase

### DIFF
--- a/server/src/__tests__/leave-seat.test.ts
+++ b/server/src/__tests__/leave-seat.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { Game } from '../game';
+
+describe('leaveSeat', () => {
+  it('refunds active bet when leaving during betting phase', () => {
+    const game = new Game();
+    const { seatIdx } = game.joinSeat('s1', 'Alice', 100);
+    game.placeBet(seatIdx, 25);
+    const seat = game.state.seats[seatIdx]!;
+
+    game.leaveSeat('s1');
+
+    expect(seat.balance).toBe(100);
+    expect(game.state.seats[seatIdx]).toBeNull();
+  });
+
+  it('refunds queued next bet when leaving before next round', () => {
+    const game = new Game();
+    const { seatIdx } = game.joinSeat('s1', 'Alice', 100);
+    game.state.phase = 'settle';
+    game.placeBet(seatIdx, 30);
+    const seat = game.state.seats[seatIdx]!;
+
+    game.leaveSeat('s1');
+
+    expect(seat.balance).toBe(100);
+    expect(game.state.seats[seatIdx]).toBeNull();
+  });
+});

--- a/server/src/game.ts
+++ b/server/src/game.ts
@@ -310,7 +310,10 @@ export class Game {
     );
     if (idx !== -1) {
       const seat = this.state.seats[idx]!;
-      if (seat.nextBet) seat.balance += seat.nextBet;
+      if (this.state.phase === 'bet' && seat.bets[0] > 0) {
+        seat.balance += seat.bets[0];
+      }
+      if (seat.nextBet !== null) seat.balance += seat.nextBet;
       this.state.seats[idx] = null;
     }
   }


### PR DESCRIPTION
## Summary
- Refund wager when a player leaves their seat during the betting phase
- Ensure queued bets are returned on leave
- Test balance is restored when leaving before play or with queued bet

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891f44a52448324865d63693f955025