### PR TITLE
Refund bet before adjusting wager

### DIFF
--- a/server/src/__tests__/place-bet.test.ts
+++ b/server/src/__tests__/place-bet.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { Game } from '../game';
+
+describe('placeBet', () => {
+  it('replaces existing bet without additional balance loss when increasing', () => {
+    const game = new Game();
+    const { seatIdx } = game.joinSeat('s1', 'Alice', 100);
+
+    game.placeBet(seatIdx, 10);
+    const seat = game.state.seats[seatIdx]!;
+    expect(seat.balance).toBe(90);
+    expect(seat.bets[0]).toBe(10);
+
+    game.placeBet(seatIdx, 20);
+    expect(seat.balance).toBe(80);
+    expect(seat.bets[0]).toBe(20);
+  });
+
+  it('replaces existing bet without additional balance loss when decreasing', () => {
+    const game = new Game();
+    const { seatIdx } = game.joinSeat('s1', 'Alice', 100);
+
+    game.placeBet(seatIdx, 30);
+    const seat = game.state.seats[seatIdx]!;
+    expect(seat.balance).toBe(70);
+    expect(seat.bets[0]).toBe(30);
+
+    game.placeBet(seatIdx, 10);
+    expect(seat.balance).toBe(90);
+    expect(seat.bets[0]).toBe(10);
+  });
+});

--- a/server/src/game.ts
+++ b/server/src/game.ts
@@ -123,8 +123,17 @@ export class Game {
   placeBet(seatIdx: number, amount: number) {
     const seat = this.state.seats[seatIdx];
     if (!seat) throw new Error();
-    if (amount > seat.balance) throw new Error('Insufficient balance');
+
+    // available balance includes any existing bet when adjusting during betting phase
+    let available = seat.balance;
+    if (this.state.phase === 'bet' && seat.bets.length > 0) {
+      available += seat.bets[0]!;
+    }
+    if (amount > available) throw new Error('Insufficient balance');
+
     if (this.state.phase === 'bet') {
+      // refund previous wager before placing a new one
+      if (seat.bets.length > 0) seat.balance += seat.bets[0]!;
       seat.bets = [amount];
       seat.hands = [[]];
       seat.activeHand = 0;


### PR DESCRIPTION
## Summary
- Ensure `placeBet` refunds any existing wager when modified during betting phase
- Cover bet replacement scenarios with new Vitest tests

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891f769e1088324a8449dabc3d6cf0b