### PR TITLE
feat: add buy-in support

### DIFF
--- a/server/src/__tests__/buy-in.test.ts
+++ b/server/src/__tests__/buy-in.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { Game } from '../game';
+
+describe('buyIn', () => {
+  it('increases seat balance by the given amount', () => {
+    const game = new Game();
+    const { seatIdx } = game.joinSeat('s1', 'Alice', 100);
+    game.buyIn(seatIdx, 50);
+    expect(game.state.seats[seatIdx]!.balance).toBe(150);
+  });
+
+  it('rejects non-positive amounts', () => {
+    const game = new Game();
+    const { seatIdx } = game.joinSeat('s1', 'Alice', 100);
+    expect(() => game.buyIn(seatIdx, 0)).toThrow();
+    expect(() => game.buyIn(seatIdx, -20)).toThrow();
+  });
+
+  it('throws for invalid seat', () => {
+    const game = new Game();
+    expect(() => game.buyIn(0, 10)).toThrow();
+  });
+});
+

--- a/server/src/game.ts
+++ b/server/src/game.ts
@@ -120,6 +120,13 @@ export class Game {
     }
   }
 
+  buyIn(seatIdx: number, amount: number) {
+    const seat = this.state.seats[seatIdx];
+    if (!seat) throw new Error('Invalid seat');
+    if (amount <= 0) throw new Error('Invalid amount');
+    seat.balance += amount;
+  }
+
   placeBet(seatIdx: number, amount: number) {
     const seat = this.state.seats[seatIdx];
     if (!seat) throw new Error();

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -30,6 +30,11 @@ io.on('connection', socket => {
     }
   });
 
+  socket.on('buyIn', ({ seatIdx, amount }) => {
+    game.buyIn(seatIdx, amount);
+    io.emit('state', game.state);
+  });
+
   socket.on('bet', ({ seatIdx, amount }) => {
     game.placeBet(seatIdx, amount);
     io.emit('state', game.state);


### PR DESCRIPTION
## Summary
- add buyIn method to Game to safely increase seat balance
- expose buyIn via new socket handler and state broadcast
- test buy-in behavior including invalid cases

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689236f0c3888324824042e5526c5fed