### PR TITLE
test: cover buying in after bust

### DIFF
--- a/server/src/__tests__/buy-in.test.ts
+++ b/server/src/__tests__/buy-in.test.ts
@@ -9,6 +9,15 @@ describe('buyIn', () => {
     expect(game.state.seats[seatIdx]!.balance).toBe(150);
   });
 
+  it('allows players with zero balance to buy back in', () => {
+    const game = new Game();
+    const { seatIdx } = game.joinSeat('s1', 'Alice', 100);
+    game.placeBet(seatIdx, 100); // drains balance to zero
+    expect(game.state.seats[seatIdx]!.balance).toBe(0);
+    game.buyIn(seatIdx, 25);
+    expect(game.state.seats[seatIdx]!.balance).toBe(25);
+  });
+
   it('rejects non-positive amounts', () => {
     const game = new Game();
     const { seatIdx } = game.joinSeat('s1', 'Alice', 100);


### PR DESCRIPTION
## Summary
- test that a player with zero balance can buy back in

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68923854840c8324ad4f720a8a881204