### PR TITLE
Handle inactive seat and buy-in on phone client

### DIFF
--- a/client-phone/src/components/BetControls.tsx
+++ b/client-phone/src/components/BetControls.tsx
@@ -5,13 +5,33 @@ interface Props {
   onBet: (amount: number) => void;
   onSkip: () => void;
   onQuit: () => void;
+  onBuyIn: (amount: number) => void;
+  inactive?: boolean;
   disabled?: boolean;
 }
 
-export default function BetControls({ balance, onBet, onSkip, onQuit, disabled }: Props) {
+export default function BetControls({ balance, onBet, onSkip, onQuit, onBuyIn, inactive, disabled }: Props) {
   const [amount, setAmount] = useState(10);
+  const [buyAmount, setBuyAmount] = useState(50);
   return (
     <div className="flex flex-col items-center space-y-4">
+      {inactive && (
+        <div className="flex flex-col items-center">
+          <label className="mb-2">Buy-In Amount</label>
+          <input
+            type="number"
+            className="border p-2 w-32 mb-2"
+            min={1}
+            value={buyAmount}
+            onChange={e => setBuyAmount(+e.target.value)}
+          />
+          <button
+            className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
+            onClick={() => onBuyIn(buyAmount)}
+            disabled={buyAmount <= 0}
+          >Buy In</button>
+        </div>
+      )}
       <div className="flex flex-col items-center">
         <label className="mb-2">Bet Amount</label>
         <p className="mb-1">Balance: ${balance}</p>
@@ -38,8 +58,9 @@ export default function BetControls({ balance, onBet, onSkip, onQuit, disabled }
         </div>
       </div>
       <button
-        className="text-red-600 underline"
+        className="text-red-600 underline disabled:opacity-50"
         onClick={onQuit}
+        disabled={disabled}
       >Quit Game</button>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add `inactive` flag to phone client Seat type and propagate through state
- Disable betting controls when bankroll depleted and expose buy-in option
- Emit `buyIn` events to reactivate seats after buying chips

## Testing
- `cd server && npm test`
- `cd client-phone && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689239f729e48324a5639c6ba84ac058